### PR TITLE
Add file storage system for gimp data

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,6 @@ module.exports = {
         "quote-props": ["error", "consistent"],
         "arrow-parens": ["error", "as-needed", { "requireForBlockBody": true }],
         "semi": ["error", "always"],
-        "max-len": ["error", { "code": 80, "ignoreUrls": true }]
+        "max-len": ["error", { "code": 100, "ignoreUrls": true }]
     }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # VSCode
 .vscode/
+
+# App-specific
+gimps.json

--- a/storage.js
+++ b/storage.js
@@ -1,0 +1,55 @@
+const fs = require("fs");
+
+class Storage {
+    /**
+     * Path to the storage file.
+     * @member {string}
+     */
+    filePath = "";
+
+    /**
+     * Encoding of the serialized data.
+     * @member {string}
+     */
+    ENCODING = "utf8";
+
+    constructor(filePath) {
+        this.filePath = filePath;
+    }
+
+    async read() {
+        return new Promise((resolve, reject) => {
+            fs.readFile(this.filePath, this.ENCODING, (err, data) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(data);
+            });
+        });
+    }
+
+    readSync() {
+        return fs.readFileSync(this.filePath, this.ENCODING);
+    }
+
+    async readJson() {
+        return JSON.parse(await this.read());
+    }
+
+    readJsonSync() {
+        return JSON.parse(this.readSync());
+    }
+
+    async write(value) {
+        return new Promise((resolve, reject) => {
+            fs.writeFile(this.filePath, JSON.stringify(value), (err) => {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            });
+        });
+    }
+}
+
+module.exports = Storage;


### PR DESCRIPTION
Adds a very basic file storage system for gimp data.

To avoid issues with concurrent attempts to access the file, the primary Storage interface, which acts on the hardcoded `./gimps.json` file, is only ever accessed on startup for the initial load and to update it with the most recent in-memory gimp data.

This update write happens on an interval instead of on demand per request, currently set to 30 seconds.

If the initial load of gimp data fails in any way, the process will exit with an error. Once gimp data has been loaded once, it cannot be loaded again for the duration of the process.